### PR TITLE
Interoperability with grpc implementations in other languages

### DIFF
--- a/example/client.php
+++ b/example/client.php
@@ -2,14 +2,14 @@
 require __DIR__.'/vendor/autoload.php';
 
 // init stub
-$service = new Helloworld\GreeterServiceStub('127.0.0.1:8080', [
+$service = new Helloworld\GreeterServiceStub(['127.0.0.1:50051'], [
     // 'use_http1' => true, // set true for fpm server
 ]);
 
 // init context
 $context = $service->newContext();
 $context->setMetadata('a-bin', '海涛');
-$context->setMetadata('content-type', 'application/grpc+json');
+//$context->setMetadata('content-type', 'application/grpc+json');
 
 // init request
 $request = new Helloworld\HelloRequest;

--- a/example/composer.json
+++ b/example/composer.json
@@ -9,10 +9,12 @@
     ],
     "autoload": {
         "psr-4": {
-            "Lv\\Grpc\\Demo\\": "./src"
+            "Lv\\Grpc\\Demo\\": "src",
+            "GPBMetadata\\": "sdk/GPBMetadata",
+            "Helloworld\\": "sdk/Helloworld"
         }
     },
     "require": {
-        "lvht/hello-sdk": "dev-master"
+        "lvht/grpc": "^1.1"
     }
 }

--- a/example/gen.sh
+++ b/example/gen.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 rm -rf sdk
 mkdir -p sdk
 protoc --php_out=sdk --plugin=protoc-gen-grpc-php=./vendor/bin/protoc-gen-grpc-php --grpc-php_out=composer_name=lvht/hello-sdk:sdk ./helloworld.proto

--- a/example/server.php
+++ b/example/server.php
@@ -1,7 +1,7 @@
 <?php
 require __DIR__.'/vendor/autoload.php';
 
-$s = new Lv\Grpc\SwooleServer('127.0.0.1', 8080);
+$s = new Lv\Grpc\SwooleServer('127.0.0.1', 50051);
 $s->addService(new Lv\Grpc\Demo\GreeterService);
 
 $s->run();

--- a/src/SdkGenerator.php
+++ b/src/SdkGenerator.php
@@ -128,7 +128,7 @@ class SdkGenerator
         /** @var MethodDescriptor $method */
         foreach ($service->getMethod() as $method_index => $method) {
             $method_name = $method->getName();
-            $p("\"/$package.$service_name/$method_name\" => \"do$method_name\",");
+            $p("\"/$package." . $service->getName() . "/$method_name\" => \"do$method_name\",");
         }
         $out();
         $p("];");

--- a/src/SdkGenerator.php
+++ b/src/SdkGenerator.php
@@ -216,7 +216,7 @@ class SdkGenerator
             $p("{");
             $p("    \$reply = new $output_type();");
             $p("");
-            $p("    \$this->send(\"/$package.$service_name/$method_name\", \$context, \$request, \$reply);");
+            $p("    \$this->send(\"/$package." . $service->getName() . "/$method_name\", \$context, \$request, \$reply);");
             $p("");
             $p("    return \$reply;");
             $p("}");
@@ -233,7 +233,7 @@ class SdkGenerator
         return $file;
     }
 
-    private function generateComposer()
+    private function generateComposer(): File
     {
         $content = <<<EOT
 {

--- a/src/SwooleSession.php
+++ b/src/SwooleSession.php
@@ -72,7 +72,7 @@ class SwooleSession implements Session
         $this->grpc_message = $message;
     }
 
-    public function end($status = null, string $body = null)
+    public function end(int $status = null, string $body = null)
     {
         if ($this->is_http2) {
             $this->response->trailer('grpc-status', $status, 0);


### PR DESCRIPTION
Current code generates service name with additional suffix `Service`, which is not present in the original protobuf scheme, for instance:
`/helloworld.GreeterService/SayHello`
This prevents usage of generated grpc client and server with implementations in other languages which expect:
`/helloworld.Greeter/SayHello`
Also changed port to `50051` - default port of all examples in grpc repository (for faster interoperability checks).
Tested with Golang server and client examples:
`go get -u google.golang.org/grpc/examples/helloworld/greeter_client`
`go get -u google.golang.org/grpc/examples/helloworld/greeter_server`